### PR TITLE
Prevent `FamilyTree` component's parameters from changing after initialization

### DIFF
--- a/samples/Blazor.FamilyTreeJS.Sample/Pages/EmptyTreeWithOptions.razor
+++ b/samples/Blazor.FamilyTreeJS.Sample/Pages/EmptyTreeWithOptions.razor
@@ -27,15 +27,14 @@
 
   private int _nodesCount = 0;
 
-  private void OnUpdateNode(UpdateNodeArgs args)
+  private Task OnUpdateNode(UpdateNodeArgs args)
   {
     _nodesCount += args.AddNodesData.Count;
     if (args.RemoveNodeId is not null)
     {
       _nodesCount -= 1;
     }
-
-    StateHasChanged();
+    return Task.CompletedTask;
   }
 
   private Node OnDefaultFirstNode()

--- a/src/Blazor.FamilyTreeJS.csproj
+++ b/src/Blazor.FamilyTreeJS.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazor.Core" Version="1.0.4" />
+    <PackageReference Include="Blazor.Core" Version="1.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.10" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.11" />

--- a/src/Components/FamilyTree.cs
+++ b/src/Components/FamilyTree.cs
@@ -152,7 +152,7 @@ public sealed partial class FamilyTree : BaseScopeComponent
     // Prevent any parameter from changing after this component
     // has been initialized. Once we know TreeId is non-null we
     // know for sure this component has been initialized and
-    // its parameter cannot be changed    
+    // its parameter cannot be changed
     if (string.IsNullOrWhiteSpace(TreeId))
     {
       await base.SetParametersAsync(parameters);

--- a/src/Components/FamilyTree.cs
+++ b/src/Components/FamilyTree.cs
@@ -146,6 +146,19 @@ public sealed partial class FamilyTree : BaseScopeComponent
     }
   }
 
+  /// <inheritdoc />
+  public override async Task SetParametersAsync(ParameterView parameters)
+  {
+    // Prevent any parameter from changing after this component
+    // has been initialized. Once we know TreeId is non-null we
+    // know for sure this component has been initialized and
+    // its parameter cannot be changed    
+    if (string.IsNullOrWhiteSpace(TreeId))
+    {
+      await base.SetParametersAsync(parameters);
+    }
+  }
+
   /// <inheritdoc/>
   protected override async ValueTask DisposeAsyncCore()
   {

--- a/src/Components/Interop/Modules/FamilyTreeInterop/FamilyTreeInteropJsModule.cs
+++ b/src/Components/Interop/Modules/FamilyTreeInterop/FamilyTreeInteropJsModule.cs
@@ -71,14 +71,14 @@ internal sealed class FamilyTreeInteropJsModule : BaseJsModule
   public async Task RegisterOnUpdateNodeCallbackAsync(string treeId, EventCallback<UpdateNodeArgs> handler)
   {
     var callbackInterop = new EventCallbackInterop<UpdateNodeArgs>(handler);
-    _callbackInterops.Add(callbackInterop);
+    CallbackInterops.Add(callbackInterop);
     await Module.InvokeVoidAsync($"{FamilyTreeJsInteropModule}.registerUpdateNodeHandler", treeId, callbackInterop);    
   }
 
   public async Task RegisterDefaultFirstNodeHandlerAsync(string treeId, Func<Node> handler)
   {
     var callbackInterop = new FuncCallbackInterop<Node>(handler);
-    _callbackInterops.Add(callbackInterop);
+    CallbackInterops.Add(callbackInterop);
 
     var functionId = $"{FamilyTreeJsInteropModule}.registerDefaultFirstNodeHandler";
     await Module.InvokeVoidAsync(functionId, treeId, callbackInterop);  
@@ -87,7 +87,7 @@ internal sealed class FamilyTreeInteropJsModule : BaseJsModule
   public async Task RegisterOnPhotoUploadCallbackAsync(string treeId, Func<PhotoUploadArgs, Task<string>> handler)
   {
     var callbackInterop = new FuncCallbackInterop<PhotoUploadArgs, Task<string>>(handler);
-    _callbackInterops.Add(callbackInterop);
+    CallbackInterops.Add(callbackInterop);
     await Module.InvokeVoidAsync($"{FamilyTreeJsInteropModule}.registerPhotoUploadHandler", treeId, callbackInterop);
   }
 
@@ -109,11 +109,11 @@ internal sealed class FamilyTreeInteropJsModule : BaseJsModule
     // disposing them in DisposeAsyncCore because the client owns those callbacks
     // and we don't want to dispose them when DestroyTreeAsync is called.
     // Calling DestroyTreeAsync() does not mean we release all resources.
-    foreach (var callbackInterop in _callbackInterops)
+    foreach (var callbackInterop in CallbackInterops)
     {
       callbackInterop.Dispose();
     }
-    _callbackInterops.Clear();
+    CallbackInterops.Clear();
   }
 
   /// <inheritdoc />

--- a/tests/Blazor.FamilyTreeJS.Tests/Components/FamilyTreeTests.razor
+++ b/tests/Blazor.FamilyTreeJS.Tests/Components/FamilyTreeTests.razor
@@ -1,5 +1,7 @@
 @inherits TestContext
 @using Blazor.FamilyTreeJS.Components
+@using Blazor.FamilyTreeJS.Components.Interop.Events
+@using Blazor.FamilyTreeJS.Components.Interop.Options
 @using NSubstitute
 
 @code
@@ -140,5 +142,44 @@
     // Arrange
     Assert.Equal("action", callbacks[0]);
     Assert.Equal("func", callbacks[1]);
+  }
+
+  [Fact]
+  public void FamilyTree_ChangeParameters_ParametersNotChanged()
+  {
+    // Arrange
+    const string treeId = "test";
+    var cut = RenderComponent<FamilyTree>(parameters
+      => parameters.Add(p => p.TreeId, treeId)
+    );
+
+    // Act
+    var emptyNodes = (new List<Node>()).AsReadOnly();
+    var onUpdateNode = new EventCallback<UpdateNodeArgs>(
+      null,
+      () => new UpdateNodeArgs(emptyNodes, emptyNodes)
+    );
+
+    cut.SetParametersAndRender(parameters => parameters
+      .Add(p => p.TreeId, "new-" + treeId)
+      .Add(p => p.Options, new())
+      .Add(p => p.OnUpdatedNode, onUpdateNode)
+      .Add(p => p.OnPhotoUpload, args => Task.FromResult(string.Empty))
+      .Add(p => p.OnDefaultFirstNode, () => new() { Id = "id-0" })
+      .Add(p => p.Style, "width: 100px; height: 100px")
+      .Add(p => p.AfterFamilyTreeRender, () => {})
+      .Add(p => p.AfterFamilyTreeRenderAsync, () => Task.CompletedTask)
+    );
+
+    // Assert
+    var familyTree = cut.Instance;
+    Assert.Equal(treeId, familyTree.TreeId);
+    Assert.Null(familyTree.Options);
+    Assert.Equal(default(EventCallback<UpdateNodeArgs>), familyTree.OnUpdatedNode);
+    Assert.Null(familyTree.OnPhotoUpload);
+    Assert.Null(familyTree.OnDefaultFirstNode);
+    Assert.Empty(familyTree.Style);
+    Assert.Null(familyTree.AfterFamilyTreeRender);
+    Assert.Null(familyTree.AfterFamilyTreeRenderAsync);
   }
 }


### PR DESCRIPTION
* Upgrade `Blazor.Core` to `v1.0.6`